### PR TITLE
include subdirectories in test directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = function (gulp, options) {
   });
 
   gulp.task('test', ['cover'], function () {
-    return gulp.src('lib/*/test/*.js')
+    return gulp.src('lib/*/test/**/*.js')
       .pipe(mocha({reporter: 'dot'}))
       .pipe(istanbul.writeReports())
       .pipe(coverageEnforcer(gulp.options.coverageSettings))


### PR DESCRIPTION
This allows for organizing tests or matching the folder structure of the lib folder when creating tests. (i know i know I should have made a branch :))
